### PR TITLE
Added initial docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM php:8.0-apache
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+RUN apt update && apt -y install zip unzip git && rm -rf /var/lib/apt/lists/*
+RUN a2enmod rewrite && docker-php-ext-install bcmath pdo_mysql
+
+COPY . /lrs
+
+ENV APACHE_DOCUMENT_ROOT /lrs/public
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
+RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+WORKDIR /lrs
+RUN composer install --optimize-autoloader --no-dev
+VOLUME /lrs/storage
+CMD mkdir -p storage/app/public storage/framework/cache/data storage/framework/sessions storage/framework/testing storage/framework/views storage/logs && php artisan config:cache && php artisan route:cache && apache2-foreground


### PR DESCRIPTION
Fixes #8 

Build it:

```bash
docker build -t traxlrs/trax2-starter-lrs:beta5
```

Use it, for example with a `docker-compose.yml`:

```yml
version: "3.8"
services:
    db:
        image: mariadb:10.5
        environment:
            - MYSQL_ROOT_PASSWORD=SuperP@55w0rd!
            - MYSQL_DATABASE=lrs
        volumes:
            - 'mysql-data:/var/lib/mysql'
    lrs:
        image: traxlrs/trax2-starter-lrs:beta5
        volumes:
            - './traxlrsdata/storage:/lrs/storage'
        environment:
            - DB_CONNECTION=mysql
            - DB_HOST=db
            - DB_PORT=3306
            - DB_DATABASE=lrs
            - DB_USERNAME=root
            - DB_PASSWORD=SuperP@55w0rd!
            - APP_NAME=TRAX LRS
            - APP_ENV=local
            - APP_KEY=base64:mlUsivEGy5Yqm/Db0jLykqFUfDpUbW4GqxfY6+3P0BQ=
            - APP_DEBUG=true
            - APP_URL=http://localhost:8080
            - XAPI_STATEMENTS_AUTHORITY_NAME=testLRS
            - XAPI_STATEMENTS_AUTHORITY_HOMEPAGE=http://localhost:8080
        ports:
            - '8080:80'
volumes:
    mysql-data:
```

Run it
```bash
docker compose up
```

The LRS is now accessible at http://localhost:8080